### PR TITLE
feat: Initial Proposal for Diagnostic Feature Codes in OpenFeature

### DIFF
--- a/src/OpenFeature.DependencyInjection/Diagnostics/FeatureCodes.cs
+++ b/src/OpenFeature.DependencyInjection/Diagnostics/FeatureCodes.cs
@@ -1,0 +1,39 @@
+namespace OpenFeature.DependencyInjection.Diagnostics;
+
+/// <summary>
+/// Contains identifiers for experimental features and diagnostics in the OpenFeature framework.
+/// </summary>
+/// <remarks>
+/// <c>Experimental</c> - This class includes identifiers that allow developers to track and conditionally enable
+/// experimental features. Each identifier follows a structured code format to indicate the feature domain,
+/// maturity level, and unique identifier. Note that experimental features are subject to change or removal 
+/// in future releases.
+/// <para>
+/// <strong>Basic Information</strong><br/>
+/// These identifiers conform to OpenFeature’s Diagnostics Specifications, allowing developers to recognize 
+/// and manage experimental features effectively. For more details, refer to the 
+/// <a href="https://github.com/open-feature/dotnet-sdk/docs/diagnostics/README.md">Diagnostics Specifications</a>.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// Code Structure:
+///     - "OF" - Represents the OpenFeature library.
+///     - "DI" - Indicates the Dependency Injection domain.
+///     - "001" - Unique identifier for a specific feature.
+/// </code>
+/// </example>
+internal static class FeatureCodes
+{
+    /// <summary>
+    /// Identifier for the experimental Dependency Injection features within the OpenFeature framework.
+    /// </summary>
+    /// <remarks>
+    /// <c>OFDI001</c> identifier marks experimental features in the Dependency Injection (DI) domain.
+    /// 
+    /// Usage:
+    /// Developers can use this identifier to conditionally enable or test experimental DI features.
+    /// It is part of the OpenFeature diagnostics system to help track experimental functionality.
+    /// </remarks>
+    public const string NewDi = "OFDI001";
+}

--- a/src/OpenFeature.DependencyInjection/Diagnostics/FeatureCodes.cs
+++ b/src/OpenFeature.DependencyInjection/Diagnostics/FeatureCodes.cs
@@ -11,8 +11,7 @@ namespace OpenFeature.DependencyInjection.Diagnostics;
 /// <para>
 /// <strong>Basic Information</strong><br/>
 /// These identifiers conform to OpenFeature’s Diagnostics Specifications, allowing developers to recognize 
-/// and manage experimental features effectively. For more details, refer to the 
-/// <a href="https://github.com/open-feature/dotnet-sdk/docs/diagnostics/README.md">Diagnostics Specifications</a>.
+/// and manage experimental features effectively.
 /// </para>
 /// </remarks>
 /// <example>

--- a/src/OpenFeature.DependencyInjection/IFeatureProviderFactory.cs
+++ b/src/OpenFeature.DependencyInjection/IFeatureProviderFactory.cs
@@ -5,6 +5,9 @@ namespace OpenFeature.DependencyInjection;
 /// This factory interface enables custom configuration and initialization of feature providers 
 /// to support domain-specific or application-specific feature flag management.
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(Diagnostics.FeatureCodes.NewDi)]
+#endif
 public interface IFeatureProviderFactory
 {
     /// <summary>

--- a/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/OpenFeatureBuilderExtensions.cs
@@ -9,6 +9,9 @@ namespace OpenFeature;
 /// <summary>
 /// Contains extension methods for the <see cref="OpenFeatureBuilder"/> class.
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(DependencyInjection.Diagnostics.FeatureCodes.NewDi)]
+#endif
 public static partial class OpenFeatureBuilderExtensions
 {
     /// <summary>

--- a/src/OpenFeature.DependencyInjection/Providers/Memory/FeatureBuilderExtensions.cs
+++ b/src/OpenFeature.DependencyInjection/Providers/Memory/FeatureBuilderExtensions.cs
@@ -5,6 +5,9 @@ namespace OpenFeature.DependencyInjection.Providers.Memory;
 /// <summary>
 /// Extension methods for configuring feature providers with <see cref="OpenFeatureBuilder"/>.
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(Diagnostics.FeatureCodes.NewDi)]
+#endif
 public static partial class FeatureBuilderExtensions
 {
     /// <summary>

--- a/src/OpenFeature.DependencyInjection/Providers/Memory/InMemoryProviderFactory.cs
+++ b/src/OpenFeature.DependencyInjection/Providers/Memory/InMemoryProviderFactory.cs
@@ -8,6 +8,9 @@ namespace OpenFeature.DependencyInjection.Providers.Memory;
 /// This factory allows for the customization of feature flags to facilitate 
 /// testing and lightweight feature flag management without external dependencies.
 /// </summary>
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(Diagnostics.FeatureCodes.NewDi)]
+#endif
 public class InMemoryProviderFactory : IFeatureProviderFactory
 {
     /// <summary>

--- a/test/OpenFeature.DependencyInjection.Tests/NoOpFeatureProviderFactory.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/NoOpFeatureProviderFactory.cs
@@ -1,5 +1,8 @@
 namespace OpenFeature.DependencyInjection.Tests;
 
+#if NET8_0_OR_GREATER
+[System.Diagnostics.CodeAnalysis.Experimental(Diagnostics.FeatureCodes.NewDi)]
+#endif
 public class NoOpFeatureProviderFactory : IFeatureProviderFactory
 {
     public FeatureProvider Create() => new NoOpFeatureProvider();

--- a/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
+++ b/test/OpenFeature.DependencyInjection.Tests/OpenFeatureBuilderExtensionsTests.cs
@@ -58,6 +58,9 @@ public partial class OpenFeatureBuilderExtensionsTests
         delegateCalled.Should().BeTrue("The delegate should be invoked.");
     }
 
+    #if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(Diagnostics.FeatureCodes.NewDi)]
+    #endif
     [Fact]
     public void AddProvider_ShouldAddProviderToCollection()
     {
@@ -73,6 +76,9 @@ public partial class OpenFeatureBuilderExtensionsTests
             "A singleton service of type FeatureProvider should be added.");
     }
 
+    #if NET8_0_OR_GREATER
+    [System.Diagnostics.CodeAnalysis.Experimental(Diagnostics.FeatureCodes.NewDi)]
+    #endif
     [Fact]
     public void AddProvider_ShouldResolveCorrectProvider()
     {


### PR DESCRIPTION
This PR introduces a new structure for **Diagnostic Feature Codes** in OpenFeature, aimed at facilitating consistent tracking and conditional enabling of experimental features. The purpose of this addition is to propose a standardized code format for community discussion and feedback.

### Summary of Changes:
- Added `FeatureCodes` class under `OpenFeature.Diagnostics` namespace to define identifiers for experimental features.
- Implemented a structured code format for diagnostics: `[Prefix][Domain][UniqueNumber]`, exemplified by `OFDI001`, where:
  - **OF** - Represents the OpenFeature library.
  - **DI** - Indicates the specific feature domain (e.g., Dependency Injection).
  - **001** - Unique identifier for each feature in the domain.

### Objectives:
This initial proposal serves as a proof of concept and a foundation for potential **Diagnostics Specifications** in OpenFeature. By aligning with best practices seen in [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/docs/diagnostics/README.md) and [EF Core diagnostics](https://github.com/dotnet/efcore/blob/main/src/Shared/EFDiagnostics.cs), we can establish a framework that:
1. Encourages a consistent and organized approach to managing experimental features.
2. Allows developers to reference and suppress diagnostic codes where necessary.
3. Simplifies tracking, documentation, and usage of evolving features.

### Community Discussion:
I encourage the community to review this initial approach and provide feedback on:
- The structured format of diagnostic codes.
- How this approach aligns with OpenFeature’s goals and usability.
- Suggestions for improvements or additional elements in a future **Diagnostics Specification** for OpenFeature.

> [!NOTE]
> I was limited in time to explore all potential aspects of this approach, but I have attempted to standardize the code format as a foundation for future enhancement. This is an initial investigation, and I hope it can serve as a basis for discussion and refinement. Please consider this a starting point, and I look forward to your insights on how we can expand or improve upon this concept.

This PR is an exploration and is open for community input. Please share any thoughts, concerns, or additional ideas for implementation.